### PR TITLE
Prototyping opentracing APIs for Voldemort store

### DIFF
--- a/bin/voldemort-server.sh
+++ b/bin/voldemort-server.sh
@@ -45,5 +45,13 @@ if [ -z "$VOLD_OPTS" ]; then
   VOLD_OPTS="-Xmx2G -server -Dcom.sun.management.jmxremote"
 fi
 
+debug_enabled=true
+
+if [[ $2 == $debug_enabled ]]; then
+  VOLD_OPTS="-Xmx2G -server -Dcom.sun.management.jmxremote -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
+fi
+
+echo $VOLD_OPTS
+
 export CLASSPATH
 java -Dlog4j.configuration=file://$base_dir/src/java/log4j.properties $VOLD_OPTS voldemort.server.VoldemortServer $@

--- a/bin/voldemort-server.sh
+++ b/bin/voldemort-server.sh
@@ -42,16 +42,14 @@ done
 CLASSPATH=$CLASSPATH:$base_dir/dist/resources
 
 if [ -z "$VOLD_OPTS" ]; then
-  VOLD_OPTS="-Xmx2G -server -Dcom.sun.management.jmxremote"
+  if [ ! -z "$VOLDEMORT_DEBUG_ENV" ]; then
+    VOLD_OPTS="-Xmx2G -server -Dcom.sun.management.jmxremote"
+  else
+    #set env var to start voldemort in debug mode
+    VOLD_OPTS="-Xmx2G -server -Dcom.sun.management.jmxremote -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
+  fi
+  echo $VOLD_OPTS
 fi
-
-debug_enabled=true
-
-if [[ $2 == $debug_enabled ]]; then
-  VOLD_OPTS="-Xmx2G -server -Dcom.sun.management.jmxremote -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
-fi
-
-echo $VOLD_OPTS
 
 export CLASSPATH
 java -Dlog4j.configuration=file://$base_dir/src/java/log4j.properties $VOLD_OPTS voldemort.server.VoldemortServer $@

--- a/build.gradle
+++ b/build.gradle
@@ -633,6 +633,14 @@ dependencies {
     compile 'com.linkedin.gobblin:gobblin-runtime:0.11.0', gobblinExcludes
     compile 'com.linkedin.gobblin:gobblin-data-management:0.11.0', gobblinExcludes
     compile 'com.linkedin.gobblin:gobblin-throttling-service-client:0.11.0', gobblinExcludes
+
+    compile group: 'io.jaegertracing', name: 'jaeger-core', version: '0.32.0'
+    compile group: 'io.jaegertracing', name: 'jaeger-client', version: '0.32.0'
+
+    compile group: 'io.opentracing', name: 'opentracing-api', version: '0.31.0'
+    compile group: 'io.opentracing', name: 'opentracing-util', version: '0.31.0'
+	
+
 }
 
 subprojects {

--- a/src/java/voldemort/server/VoldemortServer.java
+++ b/src/java/voldemort/server/VoldemortServer.java
@@ -28,6 +28,9 @@ import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
 import voldemort.VoldemortApplicationException;
 import voldemort.VoldemortException;
 import voldemort.annotations.jmx.JmxOperation;
@@ -60,6 +63,7 @@ import voldemort.store.metadata.MetadataStore;
 import voldemort.store.readonly.ReadOnlyStorageEngine;
 import voldemort.store.readonly.StoreVersionManager;
 import voldemort.store.readonly.swapper.FailedFetchLock;
+import voldemort.tracer.VoldemortTracer;
 import voldemort.utils.ByteArray;
 import voldemort.utils.JNAUtils;
 import voldemort.utils.Props;
@@ -68,9 +72,6 @@ import voldemort.utils.Utils;
 import voldemort.versioning.VectorClock;
 import voldemort.versioning.Versioned;
 import voldemort.xml.ClusterMapper;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 /**
  * This is the main server, it bootstraps all the services.
@@ -82,7 +83,6 @@ import com.google.common.collect.Lists;
 public class VoldemortServer extends AbstractService {
 
     private static final Logger logger = Logger.getLogger(VoldemortServer.class.getName());
-    public static final long DEFAULT_PUSHER_POLL_MS = 60 * 1000;
 
     private final static int ASYNC_REQUEST_CACHE_SIZE = 64;
 
@@ -109,6 +109,7 @@ public class VoldemortServer extends AbstractService {
 
         this.validateRestServiceConfiguration();
         this.basicServices = createBasicServices();
+        VoldemortTracer.configure("voldemort");
         createOnlineServices();
     }
 

--- a/src/java/voldemort/server/niosocket/AsyncRequestHandler.java
+++ b/src/java/voldemort/server/niosocket/AsyncRequestHandler.java
@@ -16,6 +16,7 @@
 
 package voldemort.server.niosocket;
 
+import io.opentracing.Scope;
 import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -42,6 +43,7 @@ import voldemort.server.protocol.RequestHandlerFactory;
 import voldemort.server.protocol.StreamRequestHandler;
 import voldemort.server.protocol.StreamRequestHandler.StreamRequestDirection;
 import voldemort.server.protocol.StreamRequestHandler.StreamRequestHandlerState;
+import voldemort.tracer.VoldemortTracer;
 import voldemort.utils.ByteUtils;
 
 /**
@@ -351,7 +353,7 @@ public class AsyncRequestHandler extends SelectorManagerWorker implements Closea
             throws IOException {
         StreamRequestHandlerState state = null;
 
-        try {
+        try (Scope scope = VoldemortTracer.buildSpan("handle-stream-request").startActive(true)) {
             if(logger.isTraceEnabled())
                 traceInputBufferState("Before streaming request handler");
 

--- a/src/java/voldemort/store/http/HttpStore.java
+++ b/src/java/voldemort/store/http/HttpStore.java
@@ -16,6 +16,7 @@
 
 package voldemort.store.http;
 
+import io.opentracing.Scope;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -36,6 +37,7 @@ import voldemort.server.RequestRoutingType;
 import voldemort.store.AbstractStore;
 import voldemort.store.StoreUtils;
 import voldemort.store.UnreachableStoreException;
+import voldemort.tracer.VoldemortTracer;
 import voldemort.utils.ByteArray;
 import voldemort.utils.VoldemortIOUtils;
 import voldemort.versioning.VectorClock;
@@ -71,7 +73,7 @@ public class HttpStore extends AbstractStore<ByteArray, byte[], byte[]> {
     public boolean delete(ByteArray key, Version version) throws VoldemortException {
         StoreUtils.assertValidKey(key);
         DataInputStream input = null;
-        try {
+        try (Scope scope = VoldemortTracer.buildSpan("http-delete").startActive(true)) {
             HttpPost method = new HttpPost(this.storeUrl);
             ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
             requestFormat.writeDeleteRequest(new DataOutputStream(outputBytes),
@@ -93,7 +95,7 @@ public class HttpStore extends AbstractStore<ByteArray, byte[], byte[]> {
     public List<Versioned<byte[]>> get(ByteArray key, byte[] transforms) throws VoldemortException {
         StoreUtils.assertValidKey(key);
         DataInputStream input = null;
-        try {
+        try (Scope scope = VoldemortTracer.buildSpan("http-get").startActive(true)) {
             HttpPost method = new HttpPost(this.storeUrl);
             ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
             requestFormat.writeGetRequest(new DataOutputStream(outputBytes),
@@ -117,7 +119,7 @@ public class HttpStore extends AbstractStore<ByteArray, byte[], byte[]> {
             throws VoldemortException {
         StoreUtils.assertValidKeys(keys);
         DataInputStream input = null;
-        try {
+        try (Scope scope = VoldemortTracer.buildSpan("http-getAll").startActive(true)) {
             HttpPost method = new HttpPost(this.storeUrl);
             ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
             requestFormat.writeGetAllRequest(new DataOutputStream(outputBytes),
@@ -140,7 +142,7 @@ public class HttpStore extends AbstractStore<ByteArray, byte[], byte[]> {
             throws VoldemortException {
         StoreUtils.assertValidKey(key);
         DataInputStream input = null;
-        try {
+        try (Scope scope = VoldemortTracer.buildSpan("http-put").startActive(true)) {
             HttpPost method = new HttpPost(this.storeUrl);
             ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
             requestFormat.writePutRequest(new DataOutputStream(outputBytes),
@@ -185,7 +187,7 @@ public class HttpStore extends AbstractStore<ByteArray, byte[], byte[]> {
     public List<Version> getVersions(ByteArray key) {
         StoreUtils.assertValidKey(key);
         DataInputStream input = null;
-        try {
+        try (Scope scope = VoldemortTracer.buildSpan("http-getVersions").startActive(true)) {
             HttpPost method = new HttpPost(this.storeUrl);
             ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
             requestFormat.writeGetVersionRequest(new DataOutputStream(outputBytes),

--- a/src/java/voldemort/store/routed/Pipeline.java
+++ b/src/java/voldemort/store/routed/Pipeline.java
@@ -16,17 +16,17 @@
 
 package voldemort.store.routed;
 
+import io.opentracing.Span;
+import org.apache.log4j.Logger;
+import voldemort.VoldemortException;
+import voldemort.store.InsufficientOperationalNodesException;
+import voldemort.store.routed.action.Action;
+
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-
-import org.apache.log4j.Logger;
-
-import voldemort.VoldemortException;
-import voldemort.store.InsufficientOperationalNodesException;
-import voldemort.store.routed.action.Action;
 
 /**
  * A Pipeline is the main conduit through which an {@link Action} is run. An
@@ -92,6 +92,7 @@ public class Pipeline {
 
     private volatile boolean finished = false;
 
+    private Span span;
     /**
      * 
      * @param operation
@@ -100,12 +101,18 @@ public class Pipeline {
      */
 
     public Pipeline(Operation operation, long timeout, TimeUnit unit) {
+        this(operation, timeout, unit, null);
+    }
+
+    public Pipeline(Operation operation, long timeout, TimeUnit unit, Span span) {
         this.operation = operation;
         this.timeout = timeout;
         this.unit = unit;
         this.eventQueue = new LinkedBlockingQueue<Event>();
         this.eventActions = new ConcurrentHashMap<Event, Action>();
+        this.span = span;
     }
+
 
     public Operation getOperation() {
         return operation;

--- a/src/java/voldemort/store/routed/PipelineData.java
+++ b/src/java/voldemort/store/routed/PipelineData.java
@@ -16,13 +16,14 @@
 
 package voldemort.store.routed;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-
+import io.opentracing.Span;
 import voldemort.VoldemortException;
 import voldemort.cluster.Node;
 import voldemort.store.routed.Pipeline.Event;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * PipelineData includes a common set of data that is used to represent the
@@ -74,6 +75,8 @@ public abstract class PipelineData<K, V> {
     protected List<Node> replicationSet;
 
     protected PipelineRoutedStats stats;
+
+    protected Span span;
 
     public void setStats(PipelineRoutedStats stats) {
         this.stats = stats;
@@ -171,5 +174,9 @@ public abstract class PipelineData<K, V> {
         if(stats != null) {
             stats.reportException(e);
         }
+    }
+
+    public Span getSpan() {
+        return span;
     }
 }

--- a/src/java/voldemort/store/socket/clientrequest/AbstractStoreClientRequest.java
+++ b/src/java/voldemort/store/socket/clientrequest/AbstractStoreClientRequest.java
@@ -16,8 +16,10 @@
 
 package voldemort.store.socket.clientrequest;
 
+import io.opentracing.Span;
 import voldemort.client.protocol.RequestFormat;
 import voldemort.server.RequestRoutingType;
+import voldemort.tracer.VoldemortTracer;
 
 public abstract class AbstractStoreClientRequest<T> extends AbstractClientRequest<T> {
 
@@ -27,12 +29,15 @@ public abstract class AbstractStoreClientRequest<T> extends AbstractClientReques
 
     protected final RequestRoutingType requestRoutingType;
 
+    protected Span span;
+
     public AbstractStoreClientRequest(String storeName,
                                       RequestFormat requestFormat,
                                       RequestRoutingType requestRoutingType) {
         this.storeName = storeName;
         this.requestFormat = requestFormat;
         this.requestRoutingType = requestRoutingType;
+        this.span = VoldemortTracer.buildSpan(storeName).start();
     }
 
 }

--- a/src/java/voldemort/tracer/VoldemortTracer.java
+++ b/src/java/voldemort/tracer/VoldemortTracer.java
@@ -1,0 +1,65 @@
+package voldemort.tracer;
+
+import io.jaegertracing.internal.JaegerTracer;
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+
+/**
+ * Allows tracing internal service modules of Voldermort.
+ * We start with Storage service for prtotyping trace since
+ * that is the fundamental use-case of voldemort
+ */
+public class VoldemortTracer {
+
+    /**
+     * Helper to get global tracer
+     */
+    public static Tracer getTracer() {
+        return GlobalTracer.get();
+    }
+
+    /**
+     * Defines specific tracer based on config, if none is available then uses
+     * {@code {@link io.opentracing.noop.NoopTracer}}.
+     * Started when server starts up and need to initialized only once.
+     *
+     * @param service
+     */
+    public static void configure(final String service) {
+
+        if(!GlobalTracer.isRegistered()) {
+            //register a simple jaeger tracer
+            GlobalTracer.register(new JaegerTracer.Builder(service).build());
+        }
+    }
+
+    /*
+     * Helper methods for starting span and scope
+     */
+    public static Scope activate(Span span, boolean finishSpanOnClose) {
+        return getTracer().scopeManager().activate(span, finishSpanOnClose);
+    }
+
+    public static Span startSpan(String operationName) {
+        return getTracer().buildSpan(operationName).start();
+    }
+
+    public static Tracer.SpanBuilder buildSpan(String operationName) {
+        return getTracer().buildSpan(operationName);
+    }
+
+    public static Scope operationTrace(String name, final String key, final String operation) {
+        Tracer.SpanBuilder spanBuilder = buildSpan(name)
+                .withTag("operation-method", operation)
+                .withTag("key", key);
+
+        return spanBuilder.startActive(false);
+    }
+
+    public static ScopeManager scopeManager() {
+        return getTracer().scopeManager();
+    }
+}

--- a/src/java/voldemort/tracer/VoldemortTracer.java
+++ b/src/java/voldemort/tracer/VoldemortTracer.java
@@ -15,13 +15,6 @@ import io.opentracing.util.GlobalTracer;
 public class VoldemortTracer {
 
     /**
-     * Helper to get global tracer
-     */
-    public static Tracer getTracer() {
-        return GlobalTracer.get();
-    }
-
-    /**
      * Defines specific tracer based on config, if none is available then uses
      * {@code {@link io.opentracing.noop.NoopTracer}}.
      * Started when server starts up and need to initialized only once.
@@ -36,15 +29,18 @@ public class VoldemortTracer {
         }
     }
 
+    /**
+     * Helper to get global tracer
+     */
+    public static Tracer getTracer() {
+        return GlobalTracer.get();
+    }
+
     /*
      * Helper methods for starting span and scope
      */
     public static Scope activate(Span span, boolean finishSpanOnClose) {
         return getTracer().scopeManager().activate(span, finishSpanOnClose);
-    }
-
-    public static Span startSpan(String operationName) {
-        return getTracer().buildSpan(operationName).start();
     }
 
     public static Tracer.SpanBuilder buildSpan(String operationName) {


### PR DESCRIPTION
A simple prototype for adding distributed trace to Voldemort. 
  - Adds opentracing and jaeger dependency to Voldemort core. 
  - Traces mainly StatTrackingStore

Below screenshots show GET and PUT operations
<img width="1434" alt="screen shot 2018-12-27 at 10 18 33 am" src="https://user-images.githubusercontent.com/237528/50490265-0a709800-09c1-11e9-987e-db9394f610d6.png">

GET
<img width="1433" alt="screen shot 2018-12-24 at 2 27 25 pm" src="https://user-images.githubusercontent.com/237528/50408294-f77d7e00-079c-11e9-962d-baab323dac3d.png">

PUT
<img width="1436" alt="screen shot 2018-12-24 at 2 29 24 pm" src="https://user-images.githubusercontent.com/237528/50408297-02381300-079d-11e9-9481-66a0a8019ffd.png">



